### PR TITLE
feat: switch to semver ParseTolerant

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 			}
 			log.Fatalf("failed to read input line: %v", err)
 		}
-		ver, err := semver.Parse(line)
+		ver, err := semver.ParseTolerant(line)
 		if err != nil {
 			log.Fatalf("failed to parse semver \"%s\": %v", line, err)
 		}


### PR DESCRIPTION
ParseTolerant allows for certain version specifications that do not
strictly adhere to semver specs to be parsed by blang/semver. It does so
by normalizing versions before passing them to Parse(). It currently
trims spaces, removes a "v" prefix, adds a 0 patch number to versions
with only major and minor components specified, and removes leading 0s.

This is useful for (e.g.,) `git tag -l | semversort`