### PR TITLE
fix: switch to using golang.org/x/mod/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/whereswaldon/semversort
 
 go 1.13
 
-require github.com/blang/semver v3.6.1+incompatible
+require golang.org/x/mod v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
-github.com/blang/semver v3.6.1+incompatible h1:RmA4CjDkwiAdjCfRQH6UZRp45n/uV30JiSkad6Acn/8=
-github.com/blang/semver v3.6.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.0 h1:sfUMP1Gu8qASkorDVjnMuvgJzwFbTZSeXFiGBYAVdl4=
+golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -2,23 +2,18 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"sort"
 
-	"github.com/blang/semver"
+	"golang.org/x/mod/semver"
 )
 
 func main() {
-	var (
-		tolerant bool
-	)
-	flag.BoolVar(&tolerant, "tolerant", false, "allow versions that do not perfectly conform to semver spec")
-	flag.Parse()
 	reader := bufio.NewReader(os.Stdin)
-	versions := make([]semver.Version, 0, 10)
+	versions := make([]string, 0, 10)
 	for {
 		// read a semver from stdin
 		line, err := reader.ReadString([]byte("\n")[0])
@@ -26,9 +21,9 @@ func main() {
 			// remove trailing newlines from input
 			line = line[:len(line)-1]
 			if len(line) > 0 {
-				// remove leading "v" if present
-				if line[0] == "v"[0] {
-					line = line[1:]
+				// add leading "v" if not present
+				if line[0] != "v"[0] {
+					line = fmt.Sprintf("v%s", line)
 				}
 			}
 		}
@@ -39,21 +34,16 @@ func main() {
 			log.Fatalf("failed to read input line: %v", err)
 		}
 
-		// use tolerant parse function if requested
-		parseFunc := semver.Parse
-		if tolerant {
-			parseFunc = semver.ParseTolerant
-		}
-
-		ver, err := parseFunc(line)
-		if err != nil {
+		if !semver.IsValid(line) {
 			log.Fatalf("failed to parse semver \"%s\": %v", line, err)
 		}
 		// collect this version
-		versions = append(versions, ver)
+		versions = append(versions, line)
 	}
 	// sort all versions
-	semver.Sort(versions)
+	sort.Slice(versions, func(i, j int) bool {
+		return semver.Compare(versions[i], versions[j]) < 0
+	})
 	// emit sorted on stdout
 	for _, v := range versions {
 		fmt.Printf("%s\n", v)


### PR DESCRIPTION
As noted in #7 the blang/semver library has a bug in its tolerant parser that
has seemingly gone unfixed for several months despite a PR being
available. Switching to use the same semver parser that `go mod` is
using internally avoids this problem and adopting the semi-official
package seems preferable anyway.