### PR TITLE
ci: remove locked go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,7 @@ jobs:
       -
         name: get go
         uses: actions/setup-go@v2
-        with:
-          go-version: '1.13'
+
       -
         name: login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin


### PR DESCRIPTION
Hopefully this will use latest. I couldn't find details in the action's documentation about this behavior, so this is something of an experiment.